### PR TITLE
Describe use of this repo in context of the others

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-This repo for APA to do a11y Review.
-See APA review project at: https://github.com/orgs/w3c/projects/155/views/1
+# Accessibility review&mdash;longitudinal tracking
+
+This repo is used by the [Accessible Platform Architectures WG](https://www.w3.org/WAI/about/groups/apawg/) to monitor the accessibility of specifications over time. We use the issues threads in this repository to tie together the results from _all_ reviews for a spec, throughout its lifetime.
+
+Spec review project: https://github.com/orgs/w3c/projects/155/views/1
+
+This is in contrast to the [a11y-request](https://github.com/w3c/a11y-request) and [a11y-tracking](https://github.com/w3c/a11y-tracking) repos, which are used to request reviews at specific times, and to track the results of those reviews.
+
+Historical longitudinal spec review can be found in the APA wiki: https://www.w3.org/WAI/APA/wiki/Category:Spec_Review


### PR DESCRIPTION
Updates the README to add more detail on what this repo is for, and contrasts it to the two main accessibility review repos that spec authors, and APA WG members, will use.

Also includes a link to the wiki for historical review info.